### PR TITLE
Fix grid visualisation

### DIFF
--- a/core/js/3d.js
+++ b/core/js/3d.js
@@ -400,8 +400,20 @@ function generateMeshGeometry(probePoints, probeRadius, xMin, xMax, yMin, yMax) 
 	var width = (xMax - xMin);
 	var height = (yMax - yMin);
 	for(var i = planeGeometry.vertices.length - 1; i >= 0; i--) {
-		var x = (planeGeometry.vertices[i].x + 0.5) * width + xMin;
-		var y = (planeGeometry.vertices[i].y + 0.5) * height + yMin;
+		if (planeGeometry.vertices[i].x < 0) {
+			var x = xMax - (Math.abs(planeGeometry.vertices[i].x) / planeWidth + 0.5) * width;
+		} else if (planeGeometry.vertices[i].x == 0) {
+			var x = 0.5 * xMax;
+		} else if (planeGeometry.vertices[i].x > 0) {
+			var x = (planeGeometry.vertices[i].x / planeWidth + 0.5) * width + xMin;
+		}
+		if (planeGeometry.vertices[i].y < 0) {
+			var y = yMax - (Math.abs(planeGeometry.vertices[i].y) / planeHeight + 0.5) * height;
+		} else if (planeGeometry.vertices[i].y == 0) {
+			var y = 0.5 * yMax;
+		} else if (planeGeometry.vertices[i].y > 0) {
+			var y = (planeGeometry.vertices[i].y / planeHeight + 0.5) * height + yMin;
+		}
 		var z = getNearestZOnGrid(probePoints, x, y) * scaleZ;
 
 		planeGeometry.vertices[i].z = z;


### PR DESCRIPTION
To transform the normalised vertex x and y values to the machine coordinate system back again they have to be divided by the height.
Also plane is created symmetric to X and Y axes so components of vertices range from half the height negative to half the height positive. So a vertex x or y value has to be subtracted from its axis max value if initial vertex value was negative or added to its axis min value if it was positive. If vertex y value is zero then it is enough to multiply its axis max value by 0.5.