### PR TITLE
Support fullscreen mode on iOS

### DIFF
--- a/core/reprap.htm
+++ b/core/reprap.htm
@@ -11,6 +11,7 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width">
+		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="description" content="Web Interface for Duet Electronics (+ Extension)">
 		<meta name="author" content="Christian Hammacher">
 


### PR DESCRIPTION
Add the appropriate meta tag so that fullscreen mode is available on iOS devices.

This does not change the normal behavior when viewing in a browser.  However, with this change if you add a bookmark to the duet web control to the iOS home screen, that shortcut will run the app in full screen mode.

