### PR TITLE
G-Code console text input overlay

### DIFF
--- a/core/reprap.htm
+++ b/core/reprap.htm
@@ -1601,7 +1601,7 @@
 								<form class="gcode-input">
 									<div class="col-xs-7 col-sm-7 col-md-8 col-lg-9">
 										<div class="input-group">
-											<input type="text" name="gcode" class="form-control" placeholder="Send G-Code..." disabled>
+											<input type="text" name="gcode" class="form-control" placeholder="Send G-Code..." autocomplete="off" disabled>
 											<div class="input-group-btn div-gcodes">
 												<button type="button" class="btn btn-default dropdown-toggle btn-gcodes disabled" data-toggle="dropdown"><span class="caret"></span></button>
 												<ul class="dropdown-menu dropdown-menu-right ul-gcodes">


### PR DESCRIPTION
The existing text input field on the G-Code console overlays the G-Code output area when a browser attempts to suggest prior values as the user is typing text. 

Adding autocomplete="off" prevents browsers from making these suggestions, and therefore prevents overlay of the output area.