### PR TITLE
Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk
+WORKDIR /dwc
+
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get update -qqy && apt-get -qqyy install nodejs zip
+RUN npm install -g yuicompressor gzip uglify-js
+RUN ln -s /usr/bin/yuicompressor /usr/bin/yui-compressor
+
+CMD ["bash", "./build.sh"]


### PR DESCRIPTION
Hi,
I created a simple Dockerfile to build DWC under Windows/OSX (and Linux too).

Use this image is very simple, you have to build the image with:

`docker build -t dwc .`

This will download all dependencies (yui-compressor, uglify etc etc) and create a ready to use image.

Now, to build everything, you have to execute the command:

`docker run --rm -v /full/path/of/dwc:/dwc dwc`

or better using $PWD (the current working dir on Linux/OSX):

`docker run --rm -v $PWD:/dwc dwc`

The result is the zip ready to be sent to the Duet :)