### PR TITLE
script requires bash to function

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Build script for Duet Web Control
 #
 # licensed under the terms of the GNU Public License v3,


### PR DESCRIPTION
Changed the script to run as /bin/bash instead of /bin/sh as it requires bash to run.

The [[ ]] syntax specifically is a bash-specific extension beyond a posix /bin/sh.

At least on ubuntu 18.04, /bin/sh is a symlink to /bin/dash instead of /bin/bash and this script did not run correctly as written.