### PR TITLE
Make estimations layout PanelDue

### DIFF
--- a/core/reprap.htm
+++ b/core/reprap.htm
@@ -1553,20 +1553,20 @@
 										<table class="table table-bordered table-condensed" id="table_estimations">
 											<tr>
 												<th>Based on</th>
-												<th>Filament Usage</th>
 												<th>File Progress</th>
+												<th>Filament Usage</th>
 												<th>Layer Time</th>
 											</tr>
 											<tr>
 												<th>Time Left</th>
-												<td id="tl_filament">n/a</td>
 												<td id="tl_file">n/a</td>
+												<td id="tl_filament">n/a</td>
 												<td id="tl_layer">n/a</td>
 											</tr>
 											<tr>
 												<th>Est. End Time</th>
-												<td id="et_filament">n/a</td>
 												<td id="et_file">n/a</td>
+												<td id="et_filament">n/a</td>
 												<td id="et_layer">n/a</td>
 											</tr>
 										</table>


### PR DESCRIPTION
The table of time estimates shows up in a different order on DWC than it does on the PanelDue screen, which I found to be confusing when going back and forth between the two.

This makes DWC's order match the PanelDue.