### PR TITLE
Fix not being able to change update interval

### DIFF
--- a/src/components/panels/SettingsWebcamPanel.vue
+++ b/src/components/panels/SettingsWebcamPanel.vue
@@ -51,7 +51,11 @@ export default {
 		},
 		webcamUpdateInterval: {
 			get() { return this.settings.webcam.updateInterval; },
-			set(value) { if (this.isNumber(value) && value >= 250) { this.update({ webcam: { updateInterval: value } }); } }
+			set(value) {
+		        	value = parseInt(value);  
+				if (!isNaN(value) && value >= 250) { 
+					this.update({ webcam: { updateInterval: value } }); } 
+				}
 		},
 		webcamFix: {
 			get() { return this.settings.webcam.fix; },

--- a/src/components/panels/SettingsWebcamPanel.vue
+++ b/src/components/panels/SettingsWebcamPanel.vue
@@ -53,7 +53,7 @@ export default {
 			get() { return this.settings.webcam.updateInterval; },
 			set(value) {
 		        	value = parseInt(value);  
-				if (!isNaN(value) && value >= 250) { 
+				if (!isNaN(value) && (value >= 250 || value === 0)) { 
 					this.update({ webcam: { updateInterval: value } }); } 
 				}
 		},


### PR DESCRIPTION
When setting the webcam update interval, the value would be a string.  Using isNumber would evaluate to false since it checks if value is the "number" type, but it has a type of string.  This was causing it to never update the webcamUpdateInterval.

I propose explicitly converting it to an integer, this avoids type coercion later on as well.  Also, allow for a value of 0.  M-JPEG image streams do not need to be updated.