### PR TITLE
Make DWC compatible with Duet behind HTTPS reverse proxy

### DIFF
--- a/src/store/machine/connector/PollConnector.js
+++ b/src/store/machine/connector/PollConnector.js
@@ -20,7 +20,7 @@ export default class PollConnector extends BaseConnector {
 	static async connect(hostname, username, password) {
 		let response;
 		try {
-			response = await axios.get(`http://${hostname}/rr_connect`, {
+			response = await axios.get(`${location.protocol}//${hostname}/rr_connect`, {
 				params: {
 					password,
 					time: timeToStr(new Date())
@@ -69,7 +69,7 @@ export default class PollConnector extends BaseConnector {
 		this.sessionTimeout = responseData.sessionTimeout || 8000;	/// default timeout in RRF is 8000ms
 
 		this.axios = axios.create({
-			baseURL: `http://${hostname}/`,
+			baseURL: `${location.protocol}//${hostname}/`,
 			cancelToken: this.cancelSource.token,
 			timeout: this.sessionTimeout
 		});
@@ -85,7 +85,7 @@ export default class PollConnector extends BaseConnector {
 
 		// Attempt to reconnect
 		try {
-			const response = await axios.get(`http://${this.hostname}/rr_connect`, {
+			const response = await axios.get(`${location.protocol}//${this.hostname}/rr_connect`, {
 				params: {
 					password: this.password,
 					time: timeToStr(new Date())

--- a/src/store/machine/connector/RestConnector.js
+++ b/src/store/machine/connector/RestConnector.js
@@ -16,7 +16,8 @@ import { strToTime } from '../../../utils/time.js'
 
 export default class RestConnector extends BaseConnector {
 	static async connect(hostname, username, password) {
-		const socket = new WebSocket(`ws://${hostname}/machine`);
+		const socketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+		const socket = new WebSocket(`${socketProtocol}//${hostname}/machine`);
 		const model = await new Promise(function(resolve, reject) {
 			socket.onmessage = function(e) {
 				// Successfully connected, the first message is the full object model
@@ -51,7 +52,7 @@ export default class RestConnector extends BaseConnector {
 		this.model = model;
 
 		this.axios = axios.create({
-			baseURL: `http://${hostname}/`,
+			baseURL:  `${location.protocol}//${hostname}/`,
 			cancelToken: this.cancelSource.token,
 			timeout: 8000		// default RRF session timeout
 		});


### PR DESCRIPTION
There were some parts in the sources where `http` was hard-coded as protocol. Usually this is not a problem since RRF does not support `https` but there are cases where RRF is hidden behind a reverse proxy that in turn is accessed via `https`.

This change replaces hard-coded `http:` by `location.protocol`. This way if the web page is accessed via `https` everything should work out of the box.

~~Note that I am not very familiar with VueJS syntax so it might be that~~
```
location.protocol + `//${hostname}`
```
~~could better be written as~~
```
`${location.protocol}//${hostname}`
```
~~If that's the case feel free to adjust this.?~~

EDIT: I changed that to the latter form.