### PR TITLE
WIP: Add drone pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,43 @@
+---
+kind: pipeline
+type: docker
+name: default
+
+# TODO: Add caching
+# TODO: Build artifacts
+
+steps:
+- name: init
+  image: node:lts
+  commands:
+    - npm install
+
+- name: lint
+  image: node:lts
+  commands:
+    - npm run lint
+  depends_on:
+    - init
+
+# - name: test
+#   image: node:lts
+#   commands:
+#     - npm run test:unit
+#   depends_on:
+#     - init
+
+# - name: translation-report
+#   image: node:lts
+#   commands:
+#     - npm run i18n:report
+#   depends_on:
+#     - init
+
+- name: build
+  image: node:lts
+  commands:
+    - npm run build
+  depends_on:
+    - init
+    - lint
+    # - test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Duet Web Control
 
-Duet Web Control is a fully-responsive HTML5-based web interface for RepRapFirmware which utilizes the Bootstrap framework, JQuery and a few other libraries to allow easy control of Duet-based 3D printer electronics.
+Duet Web Control is a fully-responsive HTML5-based web interface for RepRapFirmware which utilizes the Vue.js framework, Vuetify and a few other libraries to allow easy control of Duet-based 3D printer electronics.
 
 It is designed to communicate with RepRapFirmware using WebSockets and RESTful HTTP requests. One goal of the core application is to keep things compact, so a good loading speed can be achieved even on slow networks. Another one is to communicate to the firmware using only AJAX calls, which either return JSON objects, plain texts or binary blobs.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://cloud.drone.io/api/badges/centerorbit/DuetWebControl/status.svg?branch=add-drone-pipeline)](https://cloud.drone.io/centerorbit/DuetWebControl)
+
 # Duet Web Control
 
 Duet Web Control is a fully-responsive HTML5-based web interface for RepRapFirmware which utilizes the Vue.js framework, Vuetify and a few other libraries to allow easy control of Duet-based 3D printer electronics.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "duetwebcontrol",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "test:unit": "vue-cli-service test:unit",
     "report": "vue-cli-service build --report",
+    "i18n:report": "vue-cli-service i18n:report --src './src/**/*.?(js|vue)' --locales './src/locales/**/*.json'",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
Hello Chris,

I'm relatively new to Duet (I only started using it this year). But I have several years experience with Vue, i18n, and Vuetify, and was super glad that you made this architecture choice!

In looking through the codebase, one thing I noticed was a lack of pipeline builds. I have experience with GitLab, Drone.io, Bitbucket Cloud, Azure, and Jenkins pipelines. Of which, the first three listed are my preferred.

Since this is a GitHub hosted project, Drone.io made the most sense. Drone.io offers free pipeline builds for public projects, but if you insist on another provider, I can do my best to accommodate.

This PR is mark with WIP because you'll notice the README.md now has build badge markup (see here for example: https://github.com/centerorbit/DuetWebControl/tree/add-drone-pipeline). If you would open a https://drone.io account (go to 'Login' and authorize GitHub) and enable the DuetWebControl repo, I'll update the path to point to your "official" badge URL before this gets merged.

You can look what the pipeline looks like by checking out my current enabled repo: https://cloud.drone.io/centerorbit/DuetWebControl

You'll also notice that I've both 'test' and 'translation-report' jobs listed but commented out. I'll work on enabling these in future PRs.

I'm currently working on adding/enabling the built-in vue-i18n report functionality, but would like this PR to come back first before I finish implementing it: https://github.com/pixari/vue-i18n-extract/pull/60

Let me know if you have any questions or feedback. Thanks!