### PR TITLE
Add support for the LPC port

### DIFF
--- a/src/components/lists/SystemFileList.vue
+++ b/src/components/lists/SystemFileList.vue
@@ -99,7 +99,7 @@ export default {
 			}
 		},
 		fileEdited(filename) {
-			if (filename === Path.combine(this.directories.system, Path.configFile) && !this.isPrinting) {
+			if ((filename === Path.combine(this.directories.system, Path.configFile) || (filename === Path.combine(this.directories.system, Path.boardFile)) ) && !this.isPrinting) {
 				this.showResetPrompt = true;
 			}
 		},

--- a/src/store/machine/boards.js
+++ b/src/store/machine/boards.js
@@ -1,6 +1,16 @@
 'use strict'
 
 const boardDefinitions = {
+	LPC176x: {
+		firmwareFileRegEx: /firmware(.*)\.bin/i,
+		firmwareFile: 'firmware.bin',
+        iapFiles: [],
+        hasDisplay: true,
+        hasEthernet: true,
+        hasWiFi: true,
+        hasPowerFailureDetection: false,
+        hasMotorLoadDetection: false
+    },
 	duet06: {
 		firmwareFileRegEx: /RepRapFirmware(.*)\.bin/i,
 		firmwareFile: 'RepRapFirmware.bin',

--- a/src/utils/path.js
+++ b/src/utils/path.js
@@ -103,7 +103,7 @@ const pathObj = {
 	dwcCacheFile: '0:/sys/dwc2cache.json',
 	dwcFactoryDefaults: '0:/sys/dwc2defaults.json',
 	dwcSettingsFile: '0:/sys/dwc2settings.json',
-
+	boardFile: '0:/sys/board.txt',
 	configFile: 'config.g',
 	configBackupFile: 'config.g.bak',
 	heightmapFile: 'heightmap.csv',


### PR DESCRIPTION
Identifies the LPC from the board type.
Allows for updating of the firmware via the web interface.
Also prompts to reboot the machine if the board.txt file is edited